### PR TITLE
Fix: Ensure the training subprocess uses the correct venv interpreter

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ from queue import Queue, Empty
 from src.train import create_yaml
 from src.detect import detect_images, is_valid_image
 from src.camera import CameraDetection
+import sys
 
 # Initialize mimetypes
 mimetypes.init()
@@ -114,7 +115,7 @@ def start_training_and_capture_output(yaml_path, selected_model_size):
             return
 
         cmd_args = [
-            'python', 'src/train.py',
+            sys.executable, 'src/train.py', # Use sys.executable to ensure the subprocess uses the same venv interpreter
             project_name, train_data_path, ','.join(class_names),
             model_save_path, selected_model_size, str(input_size),
             str(epochs), yaml_path, str(batch_size)


### PR DESCRIPTION
The training script was invoked using the 'python' command, which could default to the system's global interpreter instead of the one from the activated virtual environment. This caused a 'ModuleNotFoundError' if dependencies were not installed globally.

This change replaces the hardcoded 'python' call with 'sys.executable' to ensure the training subprocess uses the same interpreter as the main application, resolving the module loading errors.

<img width="1902" height="584" alt="error-image" src="https://github.com/user-attachments/assets/825fd79d-4b43-423c-a4b8-e8a98070351e" />